### PR TITLE
Add Switch.Face <-> FaceAttachable.AttachedFace converters

### DIFF
--- a/patches/api/0005-Add-Switch.Face-FaceAttachable.AttachedFace-converte.patch
+++ b/patches/api/0005-Add-Switch.Face-FaceAttachable.AttachedFace-converte.patch
@@ -1,0 +1,77 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Wed, 5 Aug 2020 00:10:45 +0200
+Subject: [PATCH] Add Switch.Face <-> FaceAttachable.AttachedFace converters
+
+---
+ .../org/bukkit/block/data/FaceAttachable.java | 21 +++++++++++++++++++
+ .../org/bukkit/block/data/type/Switch.java    | 20 ++++++++++++++++++
+ 2 files changed, 41 insertions(+)
+
+diff --git a/src/main/java/org/bukkit/block/data/FaceAttachable.java b/src/main/java/org/bukkit/block/data/FaceAttachable.java
+index 9599e1237b9717ddbf84c3738bf6c1293e8b3c54..8c2341b03dc9f5fe62ae67d5828ed51d698de73a 100644
+--- a/src/main/java/org/bukkit/block/data/FaceAttachable.java
++++ b/src/main/java/org/bukkit/block/data/FaceAttachable.java
+@@ -1,5 +1,6 @@
+ package org.bukkit.block.data;
+ 
++import org.bukkit.block.data.type.Switch;
+ import org.jetbrains.annotations.NotNull;
+ 
+ /**
+@@ -41,5 +42,25 @@ public interface FaceAttachable extends BlockData {
+          * The switch is mounted to the ceiling and pointing dowanrds.
+          */
+         CEILING;
++
++        // Paper start
++        /**
++         * @return The {@link Switch.Face} equivalent to this.
++         * @deprecated Prefer {@link AttachedFace} over {@link Switch.Face}.
++         */
++        @Deprecated
++        public Switch.Face toSwitchFace() {
++            switch (this) {
++                case FLOOR:
++                    return Switch.Face.FLOOR;
++                case WALL:
++                    return Switch.Face.WALL;
++                case CEILING:
++                    return Switch.Face.CEILING;
++            }
++
++            throw new IllegalStateException("Unknown face: " + this);
++        }
++        // Paper end
+     }
+ }
+diff --git a/src/main/java/org/bukkit/block/data/type/Switch.java b/src/main/java/org/bukkit/block/data/type/Switch.java
+index be06f8db02ca41d5cc3a5dc02951ad27e3cc8f9d..ddfa0edb8e5c8718b10d5040d5f619134d98e45a 100644
+--- a/src/main/java/org/bukkit/block/data/type/Switch.java
++++ b/src/main/java/org/bukkit/block/data/type/Switch.java
+@@ -45,5 +45,25 @@ public interface Switch extends Directional, FaceAttachable, Powerable {
+          * The switch is mounted to the ceiling and pointing dowanrds.
+          */
+         CEILING;
++
++        // Paper start
++        /**
++         * @return The {@link AttachedFace} equivalent to this.
++         * @deprecated Prefer {@link AttachedFace} over {@link Switch.Face}.
++         */
++        @Deprecated
++        public AttachedFace toAttachedFace() {
++            switch (this) {
++                case FLOOR:
++                    return AttachedFace.FLOOR;
++                case WALL:
++                    return AttachedFace.WALL;
++                case CEILING:
++                    return AttachedFace.CEILING;
++            }
++
++            throw new IllegalStateException("Unknown face: " + this);
++        }
++        // Paper end
+     }
+ }

--- a/patches/server/0011-Async-navigation.patch
+++ b/patches/server/0011-Async-navigation.patch
@@ -1,7 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?=3D=3FUTF-8=3Fq=3F=3DE3=3D84=3D97=3DE3=3D84=3DA0=3DCB=3D8B?=
- =?UTF-8?q?=3D20=3DE3=3D84=3D91=3DE3=3D84=3DA7=3DCB=3D8A=3F=3D?=
- <tsao-chi@the-lingo.org>
+From: "tsao-chi@the-lingo.org" <tsao-chi@the-lingo.org>
 Date: Tue, 4 Aug 2020 18:29:57 +0200
 Subject: [PATCH] Async navigation
 

--- a/patches/server/0012-Add-Switch.Face-FaceAttachable.AttachedFace-converte.patch
+++ b/patches/server/0012-Add-Switch.Face-FaceAttachable.AttachedFace-converte.patch
@@ -1,0 +1,87 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Wed, 5 Aug 2020 00:10:50 +0200
+Subject: [PATCH] Add Switch.Face <-> FaceAttachable.AttachedFace converters
+
+---
+ .../org/bukkit/craftbukkit/block/data/type/CraftSwitch.java   | 4 ++--
+ .../java/org/bukkit/craftbukkit/block/impl/CraftLever.java    | 4 ++--
+ .../org/bukkit/craftbukkit/block/impl/CraftStoneButton.java   | 4 ++--
+ .../org/bukkit/craftbukkit/block/impl/CraftWoodButton.java    | 4 ++--
+ 4 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/data/type/CraftSwitch.java b/src/main/java/org/bukkit/craftbukkit/block/data/type/CraftSwitch.java
+index 2761b3710b00e317cf3ffc9ff8e1e04e48c26b79..69bbb760b93164cd764a6cc7799e586a5a010a6e 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/data/type/CraftSwitch.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/data/type/CraftSwitch.java
+@@ -9,11 +9,11 @@ public abstract class CraftSwitch extends CraftBlockData implements Switch {
+ 
+     @Override
+     public Face getFace() {
+-        return get(FACE, Face.class);
++        return get(FACE, AttachedFace.class).toSwitchFace(); // Paper
+     }
+ 
+     @Override
+     public void setFace(Face face) {
+-        set(FACE, face);
++        set(FACE, face.toAttachedFace()); // Paper
+     }
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftLever.java b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftLever.java
+index c3713d1dcfdd416853d79c61b0549537304f1c37..e69f64ccf30f6aa61d16255203f9b9aabb49f9fa 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftLever.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftLever.java
+@@ -19,12 +19,12 @@ public final class CraftLever extends org.bukkit.craftbukkit.block.data.CraftBlo
+ 
+     @Override
+     public Face getFace() {
+-        return get(FACE, Face.class);
++        return get(FACE, AttachedFace.class).toSwitchFace(); // Paper
+     }
+ 
+     @Override
+     public void setFace(Face face) {
+-        set(FACE, face);
++        set(FACE, face.toAttachedFace()); // Paper
+     }
+ 
+     // org.bukkit.craftbukkit.block.data.CraftDirectional
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftStoneButton.java b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftStoneButton.java
+index ee3bef136414ccd71998522f0b2f62909b8d87b0..b32545279bade994df589bbf2d3f5ec041c80363 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftStoneButton.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftStoneButton.java
+@@ -19,12 +19,12 @@ public final class CraftStoneButton extends org.bukkit.craftbukkit.block.data.Cr
+ 
+     @Override
+     public Face getFace() {
+-        return get(FACE, Face.class);
++        return get(FACE, AttachedFace.class).toSwitchFace(); // Paper
+     }
+ 
+     @Override
+     public void setFace(Face face) {
+-        set(FACE, face);
++        set(FACE, face.toAttachedFace()); // Paper
+     }
+ 
+     // org.bukkit.craftbukkit.block.data.CraftDirectional
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftWoodButton.java b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftWoodButton.java
+index bbe76e7ddd8c6548a00730013e5a5b85724170f9..99099ef6bb753b0ef591a87c2a97c27b86ba6b9d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftWoodButton.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftWoodButton.java
+@@ -19,12 +19,12 @@ public final class CraftWoodButton extends org.bukkit.craftbukkit.block.data.Cra
+ 
+     @Override
+     public Face getFace() {
+-        return get(FACE, Face.class);
++        return get(FACE, AttachedFace.class).toSwitchFace(); // Paper
+     }
+ 
+     @Override
+     public void setFace(Face face) {
+-        set(FACE, face);
++        set(FACE, face.toAttachedFace()); // Paper
+     }
+ 
+     // org.bukkit.craftbukkit.block.data.CraftDirectional


### PR DESCRIPTION
Fixes:

```
[20:24:39 ERROR]: Could not pass event BlockBreakEvent to CoreProtect v19.1
java.lang.ClassCastException: org.bukkit.block.data.type.Switch$Face cannot be cast to org.bukkit.block.data.FaceAttachable$AttachedFace
        at org.bukkit.craftbukkit.v1_16_R1.block.impl.CraftWoodButton.getAttachedFace(CraftWoodButton.java:55) ~[patched_1.16.1.jar:git-Paper-93]
        at net.coreprotect.bukkit.Bukkit_v1_16.buttonAttached(Bukkit_v1_16.java:99) ~[?:?]
        at net.coreprotect.listener.block.BlockBreakListener.onBlockBreak(BlockBreakListener.java:179) ~[?:?]
        at com.destroystokyo.paper.event.executor.MethodHandleEventExecutor.execute(MethodHandleEventExecutor.java:37) ~[patched_1.16.1.jar:git-Paper-93]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[patched_1.16.1.jar:git-Paper-93]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[patched_1.16.1.jar:git-Paper-93]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:607) ~[patched_1.16.1.jar:git-Paper-93]
        at net.minecraft.server.v1_16_R1.PlayerInteractManager.breakBlock(PlayerInteractManager.java:324) ~[patched_1.16.1.jar:git-Paper-93]
        at net.minecraft.server.v1_16_R1.PlayerInteractManager.a(PlayerInteractManager.java:283) ~[patched_1.16.1.jar:git-Paper-93]
        at net.minecraft.server.v1_16_R1.PlayerInteractManager.a(PlayerInteractManager.java:224) ~[patched_1.16.1.jar:git-Paper-93]
        at net.minecraft.server.v1_16_R1.PlayerConnection.a(PlayerConnection.java:1389) ~[patched_1.16.1.jar:git-Paper-93]
        at net.minecraft.server.v1_16_R1.PacketPlayInBlockDig.a(SourceFile:40) ~[patched_1.16.1.jar:git-Paper-93]
        at net.minecraft.server.v1_16_R1.PacketPlayInBlockDig.a(SourceFile:10) ~[patched_1.16.1.jar:git-Paper-93]
        at net.minecraft.server.v1_16_R1.PlayerConnectionUtils.lambda$ensureMainThread$1(PlayerConnectionUtils.java:23) ~[patched_1.16.1.jar:git-Paper-93]
        at net.minecraft.server.v1_16_R1.TickTask.run(SourceFile:18) ~[patched_1.16.1.jar:git-Paper-93]
        at net.minecraft.server.v1_16_R1.IAsyncTaskHandler.executeTask(IAsyncTaskHandler.java:136) ~[patched_1.16.1.jar:git-Paper-93]
        at net.minecraft.server.v1_16_R1.IAsyncTaskHandlerReentrant.executeTask(SourceFile:23) ~[patched_1.16.1.jar:git-Paper-93]
        at net.minecraft.server.v1_16_R1.IAsyncTaskHandler.executeNext(IAsyncTaskHandler.java:109) ~[patched_1.16.1.jar:git-Paper-93]
        at net.minecraft.server.v1_16_R1.MinecraftServer.aZ(MinecraftServer.java:1136) ~[patched_1.16.1.jar:git-Paper-93]
        at net.minecraft.server.v1_16_R1.MinecraftServer.executeNext(MinecraftServer.java:1129) ~[patched_1.16.1.jar:git-Paper-93]
        at net.minecraft.server.v1_16_R1.IAsyncTaskHandler.awaitTasks(IAsyncTaskHandler.java:119) ~[patched_1.16.1.jar:git-Paper-93]
        at net.minecraft.server.v1_16_R1.MinecraftServer.a(MinecraftServer.java:1203) ~[patched_1.16.1.jar:git-Paper-93]
        at net.minecraft.server.v1_16_R1.MinecraftServer.v(MinecraftServer.java:1000) ~[patched_1.16.1.jar:git-Paper-93]
        at net.minecraft.server.v1_16_R1.MinecraftServer.lambda$a$0(MinecraftServer.java:177) ~[patched_1.16.1.jar:git-Paper-93]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_252]
```